### PR TITLE
Add str-at primitive to Rosette

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ bin/z3
 bin/cvc4
 **/compiled
 **/compiled/**
+*~

--- a/rosette/base/primitive.rkt
+++ b/rosette/base/primitive.rkt
@@ -27,7 +27,7 @@
    << >> >>> bitwise-not bitwise-and bitwise-ior bitwise-xor 
    current-bitwidth 
    string-length str-to-int int-to-str string-append substring
-   string-contains? string-replace string-prefix? string-suffix?)))
+   string-contains? string-replace string-prefix? string-suffix? str-at)))
 
 (define (impersonate-operator op origin)
   (impersonate-procedure 
@@ -81,15 +81,16 @@
   [<< @<<] [>> @>>] [>>> @>>>]
   [bitwise-not @bitwise-not] [bitwise-and @bitwise-and] 
   [bitwise-ior @bitwise-ior] [bitwise-xor @bitwise-xor]
-  [string-length @string-length] 
+  [string-length @string-length]
   [int-to-str @int-to-str] 
-  [str-to-int @str-to-int] 
+  [str-to-int @str-to-int]
   [string-append @string-append] 
   [string-contains? @string-contains?] 
   [string-replace @string-replace] 
   [string-prefix? @string-prefix?] 
   [string-suffix? @string-suffix?] 
-  [substring @substring])
+  [substring @substring]
+  [str-at @str-at])
 
 (define @boolean=? <=>)
 (define (@add1 x) (+ x 1))

--- a/rosette/base/string.rkt
+++ b/rosette/base/string.rkt
@@ -2,7 +2,7 @@
 
 (require "term.rkt" "op.rkt" "union.rkt" "bool.rkt" "num.rkt" "any.rkt" "generic.rkt" "merge.rkt")
 
-(provide @string? @string-length @str-to-int @int-to-str @string-append @substring @string-set! @string-copy! @string-fill! @string-replace @string-contains? @string-prefix? @string-suffix?)
+(provide @string? @string-length @str-to-int @int-to-str @string-append @substring @string-set! @string-copy! @string-fill! @string-replace @string-contains? @string-prefix? @string-suffix? @str-at)
          
 (define (string/cast v)
   (match v
@@ -90,6 +90,14 @@
   #:op
   (match-lambda [(? string? x) (str-to-int x)]
                 [x (expression @str-to-int x)]))
+
+(define-op @str-at
+  #:name 'str-at
+  #:type (op/-> (@string? @number?) @string?)
+  #:pre  (case-lambda [(s i) (&& (@>= i 0) (@< i (@string-length s)))])
+  #:op
+  (match-lambda** [((? string? s) (? number? i)) (substring s i (add1 i))]
+                  [(s i) (expression @str-at s i)]))
 
 (define-op @substring
   #:name 'substring

--- a/rosette/solver/smt/enc.rkt
+++ b/rosette/solver/smt/enc.rkt
@@ -46,6 +46,8 @@
      (nat2bv (str.to.int (enc str env)) (current-bitwidth))]
     [(expression (== @int-to-str) int) 
      (int.to.str (bv2nat (enc int env)))]
+    [(expression (== @str-at) str i)
+     (str.at (enc str env) (bv2nat (enc i env)))]
     [(expression (app rosette->smt (? procedure? smt/op)) es ...)
      (apply smt/op (for/list ([e es]) (enc e env)))]
     [_ (error 'encode "cannot encode expression ~a" v)]))

--- a/test/base/string.rkt
+++ b/test/base/string.rkt
@@ -52,6 +52,11 @@
 	  (and (string-contains? t "C")
 	       (equal? t y))))))
 
+(define (ex12 x z)
+  (assert (< (string-length x) 5))
+  (assert (not (= (sub1 (string-length x)) z)))
+  (assert (equal? (str-at x z) "c")))
+
 (show "Find an assignment for x, where x.\"ab\"=\"ba\".x and the length of x equals to 7:\n x = ~s\n" ex1 x)
 (show "Find assignments for x and y, where x and y are distinct and their lengths are equal:\n x = ~s, y = ~s\n" ex2 x y)
 (show "Find assignments for x and y, where x.y != y.x.\n x = ~s, y = ~s\n" ex3 x y)
@@ -63,5 +68,6 @@
 (show "Find a string and a suffix.\n x = ~s, y = ~s\n" ex9 x y)     
 (show "Find a string that contains AB, BC and z.\n x = ~s\n" ex10 x)     
 (show "Replace ab with C.\n x = ~s, y = ~s\n" ex11 x y)     
+(show "Find a string x and an index z such that x[z] equals \"c\".\n x = ~s z = ~s" ex12 x z)
 
 


### PR DESCRIPTION
cvc4 has experimental support for str.at, which returns the
character at a given index in a string (http://cvc4.cs.nyu.edu/wiki/Strings).

This exposes str.at to Rosette.

Testing
Unit test
